### PR TITLE
on_delete_cascade追加

### DIFF
--- a/db/migrate/20240513115355_add_foreign_key_to_responses_and_contacts.rb
+++ b/db/migrate/20240513115355_add_foreign_key_to_responses_and_contacts.rb
@@ -1,0 +1,8 @@
+class AddForeignKeyToResponsesAndContacts < ActiveRecord::Migration[7.1]
+  def change
+    remove_foreign_key :responses, :users
+    remove_foreign_key :contacts, :users
+    add_foreign_key :responses, :users, column: :user_id, on_delete: :cascade
+    add_foreign_key :contacts, :users, column: :user_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_10_145652) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_13_115355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -80,10 +80,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_145652) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "contacts", "users"
+  add_foreign_key "contacts", "users", on_delete: :cascade
   add_foreign_key "responses", "players"
   add_foreign_key "responses", "requests"
   add_foreign_key "responses", "seasons"
   add_foreign_key "responses", "teams"
-  add_foreign_key "responses", "users"
+  add_foreign_key "responses", "users", on_delete: :cascade
 end


### PR DESCRIPTION
- [x] 本番環境でも親テーブル削除時に関連する子テーブルのデータも削除できるように外部キー制約にon_delete: :cascadeを追加しました。